### PR TITLE
Allow input retrieval from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ $ yarn global add deepl-translator-cli
 # Translate text into German
 $ deepl translate -t 'DE' 'How do you do?'
 
+# Pipe text from standard input
+$ echo 'How do you do?' | deepl translate -t 'DE'
+
 # Detect language
 $ deepl detect 'Wie geht es Ihnen?'
 


### PR DESCRIPTION
## Description

This contribution makes it possible for `deepl-translator-cli` to get a text to translate directly from the standard input in case no text has been given through the command-line arguments.

This makes it particularly handy to use when combined with other command-line tools that we can pipe together.

### Usage

```bash
# Using pipes.
$ echo "Il fait beau aujourd'hui" | deepl translate -t EN

# Using direct input.
$ deepl translate -t EN
Il fait beau aujourd'hui
^D

# Using input redirection.
$ deepl translate -t EN < input.txt
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Pull request checklist

- [X] Make sure the commit messages are in ([conventional commit style](https://conventionalcommits.org/)) so a changelog can be ([automatically generated](https://github.com/lob/generate-changelog)).
- [X] Make sure your changes do not fail linting checks (prettier) nor unit test.
- [X] Make sure the coverage remains at **100%** and write additional tests if needed.
- [X] Make sure to update the `README` if necessary